### PR TITLE
fix typo in raw data column name

### DIFF
--- a/finngen_qc/magic_config.py
+++ b/finngen_qc/magic_config.py
@@ -3,7 +3,7 @@ config = {
     'rename_cols' : {
         'potilashenkilotunnus':           'FINREGISTRYID',
         'tutkimusaika':                   'LAB_DATE_TIME',
-        'palveluntuottaja_organisaatio':  'LAB_SERVICE_PROVIDER',
+        'palvelutuottaja_organisaatio':  'LAB_SERVICE_PROVIDER',
         'paikallinentutkimusnimike':      'LAB_ABBREVIATION',
         'tutkimustulosarvo':              'LAB_VALUE',
         'tutkimustulosyksikkö':           'LAB_UNIT',

--- a/finngen_qc/magic_config.py
+++ b/finngen_qc/magic_config.py
@@ -3,7 +3,7 @@ config = {
     'rename_cols' : {
         'potilashenkilotunnus':           'FINREGISTRYID',
         'tutkimusaika':                   'LAB_DATE_TIME',
-        'palverluntuottaja_organisaatio': 'LAB_SERVICE_PROVIDER',
+        'palveluntuottaja_organisaatio':  'LAB_SERVICE_PROVIDER',
         'paikallinentutkimusnimike':      'LAB_ABBREVIATION',
         'tutkimustulosarvo':              'LAB_VALUE',
         'tutkimustulosyksikkö':           'LAB_UNIT',


### PR DESCRIPTION
The raw data doesn't have the typo, the typo came from data documentation.